### PR TITLE
Misc tweaks for Give / Elastic Path jobs

### DIFF
--- a/jobs/ep-jobs.yml
+++ b/jobs/ep-jobs.yml
@@ -138,6 +138,8 @@
           maven-opts: -Xmx1536m
           run-headless: true
           settings: /var/lib/jenkins/ep-settings.xml
+          run-headless: true
+          automatic-archiving: false
 
 - job:
     name: give-ep-commerce-engine-test-develop

--- a/jobs/ep-jobs.yml
+++ b/jobs/ep-jobs.yml
@@ -277,7 +277,7 @@
 
     maven:
           <<: *typicalMaven
-          goals: clean verify --batch-mode --threads 1C
+          goals: clean verify --errors --batch-mode --threads 1C
 
     reporters:
       - email:

--- a/jobs/ep-jobs.yml
+++ b/jobs/ep-jobs.yml
@@ -133,7 +133,7 @@
           skip-tag: true
           prune: true
 
-    maven:
+    maven: &typicalMaven
           goals: package -DskipAllTests --batch-mode --errors --threads 1C
           maven-opts: -Xmx1536m
           run-headless: true
@@ -165,10 +165,8 @@
             result: SUCCESS
 
     maven:
+          <<: *typicalMaven
           goals: clean install --batch-mode --update-snapshots --errors --threads 1C
-          maven-opts: -Xmx1536m
-          run-headless: true
-          settings: /var/lib/jenkins/ep-settings.xml
 
 - job:
     name: give-ep-commerce-engine-deploy-develop
@@ -196,10 +194,8 @@
             result: SUCCESS
 
     maven:
+          <<: *typicalMaven
           goals: clean deploy -P with-source-jars -DskipAllTests  --batch-mode --update-snapshots --errors
-          maven-opts: -Xmx1536m
-          run-headless: true
-          settings: /var/lib/jenkins/ep-settings.xml
 
 - job:
     name: give-ep-extensions-build-develop
@@ -228,10 +224,8 @@
             result: SUCCESS
 
     maven:
+          <<: *typicalMaven
           goals: package -DskipAllTests --update-snapshots --errors  --batch-mode --threads 1C
-          maven-opts: -Xmx1536m
-          run-headless: true
-          settings: /var/lib/jenkins/ep-settings.xml
 
 - job:
     name: give-ep-extensions-test-develop
@@ -259,10 +253,8 @@
             result: SUCCESS
 
     maven:
+          <<: *typicalMaven
           goals: clean test --batch-mode --threads 1C
-          maven-opts: -Xmx1536m
-          run-headless: true
-          settings: /var/lib/jenkins/ep-settings.xml
 
 - job:
     name: give-ep-extensions-deploy-develop
@@ -290,10 +282,8 @@
             result: SUCCESS
 
     maven:
+          <<: *typicalMaven
           goals: clean deploy --update-snapshots --errors --batch-mode
-          maven-opts: -Xmx1536m
-          run-headless: true
-          settings: /var/lib/jenkins/ep-settings.xml
 
 - job:
     name: give-ep-cmclient-build-develop
@@ -321,10 +311,8 @@
             result: SUCCESS
 
     maven:
+          <<: *typicalMaven
           goals: clean deploy -P multi-platform --update-snapshots --errors  --batch-mode
-          maven-opts: -Xmx1536m
-          run-headless: true
-          settings: /var/lib/jenkins/ep-settings.xml
 
 - job:
     name: give-ep-deployment-package-deploy-develop
@@ -352,8 +340,5 @@
             result: SUCCESS
 
     maven:
+          <<: *typicalMaven
           goals: clean deploy --update-snapshots --errors  --batch-mode
-          maven-opts: -Xmx1536m
-          run-headless: true
-          settings: /var/lib/jenkins/ep-settings.xml
-

--- a/jobs/ep-jobs.yml
+++ b/jobs/ep-jobs.yml
@@ -277,7 +277,7 @@
 
     maven:
           <<: *typicalMaven
-          goals: clean test --batch-mode --threads 1C
+          goals: clean verify --batch-mode --threads 1C
 
     reporters:
       - email:

--- a/jobs/ep-jobs.yml
+++ b/jobs/ep-jobs.yml
@@ -112,6 +112,11 @@
           -f ../environments/uat/database.properties \
           -p ../target/ext-deployment-package-0-*.zip -d update-db;
 
+    reporters:
+      - email: &typicalEmail
+          recipients: 'matt.drees@cru.org, dhughes@xumak.com'
+          send-to-individuals: true
+
 - job:
     name: give-ep-commerce-engine-build-develop
     project-type: maven
@@ -140,6 +145,10 @@
           settings: /var/lib/jenkins/ep-settings.xml
           run-headless: true
           automatic-archiving: false
+
+    reporters:
+      - email:
+          <<: *typicalEmail
 
 - job:
     name: give-ep-commerce-engine-test-develop
@@ -170,6 +179,10 @@
           <<: *typicalMaven
           goals: clean install --batch-mode --update-snapshots --errors --threads 1C
 
+    reporters:
+      - email:
+          <<: *typicalEmail
+
 - job:
     name: give-ep-commerce-engine-deploy-develop
     project-type: maven
@@ -198,6 +211,10 @@
     maven:
           <<: *typicalMaven
           goals: clean deploy -P with-source-jars -DskipAllTests  --batch-mode --update-snapshots --errors
+
+    reporters:
+      - email:
+          <<: *typicalEmail
 
 - job:
     name: give-ep-extensions-build-develop
@@ -229,6 +246,10 @@
           <<: *typicalMaven
           goals: package -DskipAllTests --update-snapshots --errors  --batch-mode --threads 1C
 
+    reporters:
+      - email:
+          <<: *typicalEmail
+
 - job:
     name: give-ep-extensions-test-develop
     project-type: maven
@@ -257,6 +278,10 @@
     maven:
           <<: *typicalMaven
           goals: clean test --batch-mode --threads 1C
+
+    reporters:
+      - email:
+          <<: *typicalEmail
 
 - job:
     name: give-ep-extensions-deploy-develop
@@ -287,6 +312,10 @@
           <<: *typicalMaven
           goals: clean deploy --update-snapshots --errors --batch-mode
 
+    reporters:
+      - email:
+          <<: *typicalEmail
+
 - job:
     name: give-ep-cmclient-build-develop
     project-type: maven
@@ -316,6 +345,10 @@
           <<: *typicalMaven
           goals: clean deploy -P multi-platform --update-snapshots --errors  --batch-mode
 
+    reporters:
+      - email:
+          <<: *typicalEmail
+
 - job:
     name: give-ep-deployment-package-deploy-develop
     project-type: maven
@@ -344,3 +377,7 @@
     maven:
           <<: *typicalMaven
           goals: clean deploy --update-snapshots --errors  --batch-mode
+
+    reporters:
+      - email:
+          <<: *typicalEmail


### PR DESCRIPTION
This includes several manual changes I've made to jenkins.uscm.org recently.

I would have liked to have added `per-module-email: false` in the email reporter settings, but it seems that is not implemented in our version of JJB. This will typically mean I'll get two emails in stead of one when a job fails; not a biggie for now.