### PR TITLE
removes trigger from give-ep-docker-images-master

### DIFF
--- a/jobs/ep-jobs.yml
+++ b/jobs/ep-jobs.yml
@@ -524,9 +524,6 @@
           skip-tag: true
           prune: true
 
-    triggers:
-      - github
-
     builders:
       - maven-target:
           maven-version: maven v3.3.9


### PR DESCRIPTION
This job wasn't supposed to have a github trigger in it.  Unlike the "develop" version, the "master" version will be triggered by a special release job.