### PR TITLE
Ep add promotion info

### DIFF
--- a/jobs/ep-jobs.yml
+++ b/jobs/ep-jobs.yml
@@ -1,47 +1,6 @@
 # Jobs that build from the develop branch and deploy to UAT
 
 - job:
-    name: give-ep-docker-images-develop
-    description: |
-      Build EP docker images for UAT from develop branch
-    jdk: JDK8
-
-    properties:
-      - github:
-          url: https://github.com/CruGlobal/give-ep-devops/
-
-    scm:
-      - git:
-          branches:
-            - origin/develop
-          url: git@github.com:CruGlobal/give-ep-devops.git
-          wipe-workspace: false
-          skip-tag: true
-          prune: true
-
-    triggers:
-      - github
-      - reverse:
-            jobs: give-ep-deployment-package-deploy-develop
-            result: SUCCESS
-
-    builders:
-      - maven-target:
-          maven-version: maven v3.3.9
-          goals: clean install -DskipAllTests --batch-mode --errors --update-snapshots
-          java_opts:
-            - "-Xmx200m -XX:MaxPermSize=256m"
-          settings: ${JENKINS_HOME}/ep-settings.xml
-
-      - shell: |
-          cd docker-setup/DockerImageBuilder/
-          ./DockerImageBuilder.sh \
-          -p $WORKSPACE/pusher-package/target/ext-deployment-package-0-*.zip \
-          -f config/docker-build-development.conf \
-          -e development \
-          -t $GIT_COMMIT-$BUILD_NUMBER
-
-- job:
     name: give-ep-deploy-staging
     description: |
       Deploys the Give / Elastic path apps to UAT (aka Staging).
@@ -496,52 +455,6 @@
           - project: give-ep-docker-images-master
             predefined-parameters: |
               RELEASE_NUMBER=${RELEASE_NUMBER}
-
-
-- job:
-    name: give-ep-docker-images-master
-    description: |
-      Build EP docker images for Production from master branch
-    jdk: JDK8
-
-    parameters:
-      - string:
-          name: RELEASE_NUMBER
-          description: |
-            The maven version of the extensions deployment package to build/deploy.
-            This will normally be the build number of the jenkins job that built that package.
-
-    properties:
-      - github:
-          url: https://github.com/CruGlobal/give-ep-devops/
-
-    scm:
-      - git:
-          branches:
-            - origin/master
-          url: git@github.com:CruGlobal/give-ep-devops.git
-          wipe-workspace: false
-          skip-tag: true
-          prune: true
-
-    builders:
-      - maven-target:
-          maven-version: maven v3.3.9
-          settings: ${JENKINS_HOME}/ep-settings.xml
-          goals: |
-            clean
-            install
-            --batch-mode
-            --errors
-            -Dapplication.package.version=${RELEASE_NUMBER}
-
-      - shell: |
-          cd docker-setup/DockerImageBuilder/
-          ./DockerImageBuilder.sh \
-          -p $WORKSPACE/pusher-package/target/ext-deployment-package-${RELEASE_NUMBER}.zip \
-          -f config/docker-build-production.conf \
-          -e production \
-          -t $GIT_COMMIT-${RELEASE_NUMBER}
 
 - job:
     name: give-ep-deploy-production

--- a/jobs/ep-jobs.yml
+++ b/jobs/ep-jobs.yml
@@ -1,4 +1,4 @@
-# Jobs that build from the develop branch and deploy to UAT
+# Jobs that build from the develop branch and deploy to UAT / Staging
 
 - job:
     name: give-ep-deploy-staging
@@ -644,6 +644,8 @@
     reporters:
       - email:
           <<: *typicalEmail
+
+# Jobs that build from the develop branch and deploy to Test
 
 - job:
     name: give-ep-deploy-test

--- a/jobs/ep-promotable-jobs.yml
+++ b/jobs/ep-promotable-jobs.yml
@@ -1,0 +1,98 @@
+- project:
+    name: give-ep-docker-images-develop
+    jobs:
+      - give-ep-docker-images-develop
+
+- project:
+    name: give-ep-docker-images-master
+    jobs:
+      - give-ep-docker-images-master
+
+- job-template:
+    name: give-ep-docker-images-develop
+    description: |
+      Build EP docker images for UAT from develop branch
+    jdk: JDK8
+    environment: staging
+
+    properties:
+      - github:
+          url: https://github.com/CruGlobal/give-ep-devops/
+
+    scm:
+      - git:
+          branches:
+            - origin/develop
+          url: git@github.com:CruGlobal/give-ep-devops.git
+          wipe-workspace: false
+          skip-tag: true
+          prune: true
+
+    triggers:
+      - github
+      - reverse:
+            jobs: give-ep-deployment-package-deploy-develop
+            result: SUCCESS
+
+    builders:
+      - maven-target:
+          maven-version: maven v3.3.9
+          goals: clean install -DskipAllTests --batch-mode --errors --update-snapshots
+          java_opts:
+            - "-Xmx200m -XX:MaxPermSize=256m"
+          settings: ${JENKINS_HOME}/ep-settings.xml
+
+      - shell: |
+          cd docker-setup/DockerImageBuilder/
+          ./DockerImageBuilder.sh \
+          -p $WORKSPACE/pusher-package/target/ext-deployment-package-0-*.zip \
+          -f config/docker-build-development.conf \
+          -e development \
+          -t $GIT_COMMIT-$BUILD_NUMBER
+
+
+- job-template:
+    name: give-ep-docker-images-master
+    description: |
+      Build EP docker images for Production from master branch
+    jdk: JDK8
+    environment: production
+
+    parameters:
+      - string:
+          name: RELEASE_NUMBER
+          description: |
+            The maven version of the extensions deployment package to build/deploy.
+            This will normally be the build number of the jenkins job that built that package.
+
+    properties:
+      - github:
+          url: https://github.com/CruGlobal/give-ep-devops/
+
+    scm:
+      - git:
+          branches:
+            - origin/master
+          url: git@github.com:CruGlobal/give-ep-devops.git
+          wipe-workspace: false
+          skip-tag: true
+          prune: true
+
+    builders:
+      - maven-target:
+          maven-version: maven v3.3.9
+          settings: ${JENKINS_HOME}/ep-settings.xml
+          goals: |
+            clean
+            install
+            --batch-mode
+            --errors
+            -Dapplication.package.version=${RELEASE_NUMBER}
+
+      - shell: |
+          cd docker-setup/DockerImageBuilder/
+          ./DockerImageBuilder.sh \
+          -p $WORKSPACE/pusher-package/target/ext-deployment-package-${RELEASE_NUMBER}.zip \
+          -f config/docker-build-production.conf \
+          -e production \
+          -t $GIT_COMMIT-${RELEASE_NUMBER}

--- a/jobs/ep-promotable-jobs.yml
+++ b/jobs/ep-promotable-jobs.yml
@@ -98,7 +98,7 @@
       - shell: |
           cd docker-setup/DockerImageBuilder/
           ./DockerImageBuilder.sh \
-          -p $WORKSPACE/pusher-package/target/ext-deployment-package-${RELEASE_NUMBER}.zip \
+          -p $WORKSPACE/pusher-package/target/ext-deployment-package-${{RELEASE_NUMBER}}.zip \
           -f config/docker-build-production.conf \
           -e production \
           -t $GIT_COMMIT-${{RELEASE_NUMBER}}

--- a/jobs/ep-promotable-jobs.yml
+++ b/jobs/ep-promotable-jobs.yml
@@ -1,10 +1,12 @@
 - project:
     name: give-ep-docker-images-develop
+    environment: staging
     jobs:
       - give-ep-docker-images-develop
 
 - project:
     name: give-ep-docker-images-master
+    environment: production
     jobs:
       - give-ep-docker-images-master
 
@@ -13,7 +15,6 @@
     description: |
       Build EP docker images for UAT from develop branch
     jdk: JDK8
-    environment: staging
 
     properties:
       - github:
@@ -59,7 +60,6 @@
     description: |
       Build EP docker images for Production from master branch
     jdk: JDK8
-    environment: production
 
     parameters:
       - string:

--- a/jobs/ep-promotable-jobs.yml
+++ b/jobs/ep-promotable-jobs.yml
@@ -18,6 +18,9 @@
     properties:
       - github:
           url: https://github.com/CruGlobal/give-ep-devops/
+      - promoted-build:
+            names:
+              - Deploy to Staging
 
     scm:
       - git:
@@ -68,6 +71,9 @@
     properties:
       - github:
           url: https://github.com/CruGlobal/give-ep-devops/
+      - promoted-build:
+            names:
+              - Deploy to Production
 
     scm:
       - git:

--- a/jobs/ep-promotable-jobs.yml
+++ b/jobs/ep-promotable-jobs.yml
@@ -93,7 +93,7 @@
             install
             --batch-mode
             --errors
-            -Dapplication.package.version=${RELEASE_NUMBER}
+            -Dapplication.package.version=${{RELEASE_NUMBER}}
 
       - shell: |
           cd docker-setup/DockerImageBuilder/

--- a/jobs/ep-promotable-jobs.yml
+++ b/jobs/ep-promotable-jobs.yml
@@ -43,7 +43,7 @@
           goals: clean install -DskipAllTests --batch-mode --errors --update-snapshots
           java_opts:
             - "-Xmx200m -XX:MaxPermSize=256m"
-          settings: ${JENKINS_HOME}/ep-settings.xml
+          settings: ${{JENKINS_HOME}}/ep-settings.xml
 
       - shell: |
           cd docker-setup/DockerImageBuilder/
@@ -87,7 +87,7 @@
     builders:
       - maven-target:
           maven-version: maven v3.3.9
-          settings: ${JENKINS_HOME}/ep-settings.xml
+          settings: ${{JENKINS_HOME}}/ep-settings.xml
           goals: |
             clean
             install
@@ -101,4 +101,4 @@
           -p $WORKSPACE/pusher-package/target/ext-deployment-package-${RELEASE_NUMBER}.zip \
           -f config/docker-build-production.conf \
           -e production \
-          -t $GIT_COMMIT-${RELEASE_NUMBER}
+          -t $GIT_COMMIT-${{RELEASE_NUMBER}}

--- a/jobs/ep-promotion-config.xml
+++ b/jobs/ep-promotion-config.xml
@@ -1,0 +1,50 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson.plugins.promoted__builds.PromotionProcess>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <conditions>
+    <hudson.plugins.promoted__builds.conditions.ManualCondition>
+      <users></users>
+      <parameterDefinitions/>
+    </hudson.plugins.promoted__builds.conditions.ManualCondition>
+  </conditions>
+  <icon>{{icon}}</icon>
+  <isVisible></isVisible>
+  <buildSteps>
+    <hudson.plugins.parameterizedtrigger.BuildTrigger>
+      <configs>
+        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>GIT_COMMIT=${PROMOTED_GIT_COMMIT}
+BUILD_NUMBER=${PROMOTED_NUMBER}</properties>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>give-ep-deploy-{{environment}}</projects>
+          <condition>SUCCESS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+          <triggerFromChildProjects>false</triggerFromChildProjects>
+        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+      </configs>
+    </hudson.plugins.parameterizedtrigger.BuildTrigger>
+    <hudson.plugins.parameterizedtrigger.TriggerBuilder>
+      <configs>
+        <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+          <configs class="empty-list"/>
+          <projects>give-ep-update-db-{{environment}}</projects>
+          <condition>ALWAYS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+          <triggerFromChildProjects>false</triggerFromChildProjects>
+          <buildAllNodesWithLabel>false</buildAllNodesWithLabel>
+        </hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+      </configs>
+    </hudson.plugins.parameterizedtrigger.TriggerBuilder>
+  </buildSteps>
+</hudson.plugins.promoted__builds.PromotionProcess>

--- a/jobs/ep-promotion-config.xml
+++ b/jobs/ep-promotion-config.xml
@@ -40,7 +40,7 @@ BUILD_NUMBER=${PROMOTED_NUMBER}</properties>
           <configs>
             <hudson.plugins.parameterizedtrigger.CurrentBuildParameters/>
           </configs>
-          <projects>give-ep-update-db-prod</projects>
+          <projects>give-ep-update-db-{{environment}}</projects>
           <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>

--- a/jobs/ep-promotion-config.xml
+++ b/jobs/ep-promotion-config.xml
@@ -34,19 +34,18 @@ BUILD_NUMBER=${PROMOTED_NUMBER}</properties>
         </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
       </configs>
     </hudson.plugins.parameterizedtrigger.BuildTrigger>
-    <hudson.plugins.parameterizedtrigger.TriggerBuilder>
+    <hudson.plugins.parameterizedtrigger.BuildTrigger>
       <configs>
-        <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
           <configs>
             <hudson.plugins.parameterizedtrigger.CurrentBuildParameters/>
           </configs>
           <projects>give-ep-update-db-prod</projects>
-          <condition>ALWAYS</condition>
+          <condition>SUCCESS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>
-          <buildAllNodesWithLabel>false</buildAllNodesWithLabel>
-        </hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
       </configs>
-    </hudson.plugins.parameterizedtrigger.TriggerBuilder>
+    </hudson.plugins.parameterizedtrigger.BuildTrigger>
   </buildSteps>
 </hudson.plugins.promoted__builds.PromotionProcess>

--- a/jobs/ep-promotion-config.xml
+++ b/jobs/ep-promotion-config.xml
@@ -37,8 +37,10 @@ BUILD_NUMBER=${PROMOTED_NUMBER}</properties>
     <hudson.plugins.parameterizedtrigger.TriggerBuilder>
       <configs>
         <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
-          <configs class="empty-list"/>
-          <projects>give-ep-update-db-{{environment}}</projects>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.CurrentBuildParameters/>
+          </configs>
+          <projects>give-ep-update-db-prod</projects>
           <condition>ALWAYS</condition>
           <triggerWithNoParameters>false</triggerWithNoParameters>
           <triggerFromChildProjects>false</triggerFromChildProjects>

--- a/update_jobs.sh
+++ b/update_jobs.sh
@@ -6,4 +6,5 @@ jenkins-jobs --conf jenkins_jobs.ini update jobs/app-jobs.yml $@
 jenkins-jobs --conf jenkins_jobs.ini update jobs/java-docker-jobs.yml $@
 jenkins-jobs --conf jenkins_jobs.ini update jobs/java-jobs.yml $@
 jenkins-jobs --conf jenkins_jobs.ini update jobs/ep-jobs.yml $@
+jenkins-jobs --conf jenkins_jobs.ini update jobs/ep-promotable-jobs.yml $@
 python update_promotable_jobs.py $@


### PR DESCRIPTION
Matt, let me know if you're OK with this way of structuring update_promotable_jobs.py to handle the differences between the EP jobs and the more standard jobs.  They differ in two aspects: the xml that needs to be POSTed, and the way that each EP job only gets promoted to a single environment, not to staging and production as with the more standard jobs.

Also, in ep-promotable-jobs.yml I added the level of "project" so that the parsing of job information from EP jobs would be the same as with the other jobs.