### PR TITLE
Update java docker jobs with new image naming pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Cru Jenkins Job Configuration
 
 This project contains configuration for all jobs running on jenkins-prod.cru.org.
 
-How to Add a Job
+How to Add or Update a Job
 ----------------
 * Create a feature branch and add your job definition to the appropriate yaml file.
   * app-jobs.yml --> Ruby on Rails, PHP, openresty and react apps running on ECS/Docker
@@ -12,6 +12,18 @@ How to Add a Job
   * java-docker-jobs.yml --> Java apps running on ECS/docker
   * java-jobs.yml --> Java apps running in a non-containerized environment
   * simple-jobs.yml --> Docker image build jobs and other misc jobs
-* Issue a pull request against master and assign to Mike Albert or Matt Drees
+* Test your work
+  * Push your feature branch to github
+  * Request Mike Albert to turn on Jenkins Lab, if jenkins-lab.cru.org gives you a 503.
+  * Manually tweak the "Execute Shell" step of create-jenkins-job's [config][1]
+    to use your feature branch.
+    (See the comment there for the syntax.)
+  * Run create-jenkins-job to make your job changes, and run your new or updated job.
+  * Repeat until bugs are gone
+* Issue a pull request against master and request a code review from Mike Albert or Matt Drees
 * After approval has been given, merge to master and delete the feature branch
-* To create your new job on Jenkins, run the "create-jenkins-jobs" job on Jenkins Production.
+* To create your new job on Jenkins, run the "create-jenkins-jobs" [job][2] on Jenkins Production.
+
+
+[1]: https://jenkins-lab.cru.org/job/create-jenkins-jobs/configure
+[2]: https://jenkins-prod.cru.org/job/create-jenkins-jobs/

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ This project contains configuration for all jobs running on jenkins-prod.cru.org
 How to Add a Job
 ----------------
 * Create a feature branch and add your job definition to the appropriate yaml file.
- * app-jobs.yml --> Ruby on Rails, PHP, openresty and react apps running on ECS/Docker
- * ep-jobs.yml --> ElasticPath jobs
- * ep-promotable-jobs.yml --> ElasticPath jobs that use the promotable jobs plugin
- * java-docker-jobs.yml --> Java apps running on ECS/docker
- * java-jobs.yml --> Java apps running in a non-containerized environment
- * simple-jobs.yml --> Docker image build jobs and other misc jobs
+  * app-jobs.yml --> Ruby on Rails, PHP, openresty and react apps running on ECS/Docker
+  * ep-jobs.yml --> ElasticPath jobs
+  * ep-promotable-jobs.yml --> ElasticPath jobs that use the promotable jobs plugin
+  * java-docker-jobs.yml --> Java apps running on ECS/docker
+  * java-jobs.yml --> Java apps running in a non-containerized environment
+  * simple-jobs.yml --> Docker image build jobs and other misc jobs
 * Issue a pull request against master and assign to Mike Albert or Matt Drees
 * After approval has been given, merge to master and delete the feature branch
 * To create your new job on Jenkins, run the "create-jenkins-jobs" job on Jenkins Production.

--- a/jobs/java-docker-jobs.yml
+++ b/jobs/java-docker-jobs.yml
@@ -148,13 +148,30 @@
 
     maven:
       root-pom: pom.xml
-      goals: 'clean package -Dimage.tag=${{ENVIRONMENT}}-${{BUILD_NUMBER}} -P CI -DskipTests'
+      goals: 'clean package -Dimage.tag=${{BUILD_NUMBER}} -P CI -DskipTests'
       post-step-run-condition: SUCCESS
 
     postbuilders:
       - shell: |
-          docker push 056154071827.dkr.ecr.us-east-1.amazonaws.com/{name}:${{ENVIRONMENT}}-${{BUILD_NUMBER}};
-          docker rmi 056154071827.dkr.ecr.us-east-1.amazonaws.com/{name}:${{ENVIRONMENT}}-${{BUILD_NUMBER}};
+
+          # strip off the '<remote-name>/' prefix, typically 'origin'
+          BRANCH_NAME="${{GIT_BRANCH#*/}}"
+
+          case "$BRANCH_NAME" in
+            master) ENVIRONMENT="production" ;;
+            *) ENVIRONMENT="staging" ;;
+          esac
+
+          DOCKER_TAG="${{ENVIRONMENT}}-${{BUILD_NUMBER}}"
+
+          DOCKER_REPO="056154071827.dkr.ecr.us-east-1.amazonaws.com"
+
+          docker tag \
+            ${{DOCKER_REPO}}/{name}:${{BUILD_NUMBER}} \
+            ${{DOCKER_REPO}}/{name}:${{DOCKER_TAG}};
+          docker push ${{DOCKER_REPO}}/{name}:${{DOCKER_TAG}};
+          docker rmi ${{DOCKER_REPO}}/{name}:${{DOCKER_TAG}};
+          docker rmi ${{DOCKER_REPO}}/{name}:${{BUILD_NUMBER}};
 
     wrappers:
       - build-name:

--- a/jobs/simple-jobs.yml
+++ b/jobs/simple-jobs.yml
@@ -195,7 +195,16 @@
 - job:
     name: create-jenkins-jobs
     description: |
-      Create new jenkins jobs.
+      Create and update jenkins jobs.
+
+      This configures/reconfigures all of the jobs in the jenkins-jobs repo.
+
+      Note: there is one exception to the above:
+      executing this job does not rebuild the config for *this* job (create-jenkins-jobs).
+      This is true at the time of writing, anyway, and it's not obvious why it is.
+      Fortunately, this makes it easier to test other job config changes,
+      since manual tweaks to the shell builder below will not be blown away.
+
 
     properties:
       - github:
@@ -210,4 +219,7 @@
           skip-tag: true
 
     builders:
-      - shell: ansible-playbook aws_jenkins_add_jobs.yml --tags="jjb_add_jobs"
+      - shell: |
+        # if this is jenkins-lab.cru.org, and you want to test your jenkins-jobs changes,
+        # manually add `--extra-vars="jenkins_jobs_version=insert-your-jenkins-job-branch"` below.
+        ansible-playbook aws_jenkins_add_jobs.yml --tags="jjb_add_jobs"


### PR DESCRIPTION
This fixes a problem in the ert-api build caused by the image naming convention change in https://github.com/CruGlobal/ecs_config/pull/212.

It also makes it easier to test job config changes.
This requires cru-ansible change https://github.com/CruGlobal/cru-ansible/pull/219.

The ert-api problem is blocking deployment of https://github.com/CruGlobal/ert-api/pull/722.