### PR TITLE
pass command line args into the pipeline jobs call

### DIFF
--- a/update_jobs.sh
+++ b/update_jobs.sh
@@ -7,5 +7,5 @@ jenkins-jobs --conf jenkins_jobs.ini update jobs/java-docker-jobs.yml $@
 jenkins-jobs --conf jenkins_jobs.ini update jobs/java-jobs.yml $@
 jenkins-jobs --conf jenkins_jobs.ini update jobs/ep-jobs.yml $@
 jenkins-jobs --conf jenkins_jobs.ini update jobs/ep-promotable-jobs.yml $@
-jenkins-jobs --conf jenkins_jobs.ini update jobs/pipeline-jobs.yml
+jenkins-jobs --conf jenkins_jobs.ini update jobs/pipeline-jobs.yml $@
 python update_promotable_jobs.py $@


### PR DESCRIPTION
Just like the others in this file.
I forgot this in b85b69c901e0d2b337001e528cde4bccc2aa7c3d.
However, I don't think it has effected anything, since the ansible script calls this with no arguments.