### PR TITLE
Discard java docker jobs older than 64 days

### DIFF
--- a/jobs/java-docker-jobs.yml
+++ b/jobs/java-docker-jobs.yml
@@ -60,6 +60,9 @@
             names:
               - Deploy to Staging
               - Deploy to Production
+      - build-discarder:
+          days-to-keep: 64
+          artifact-days-to-keep: 64
 
     node: linux
     scm:


### PR DESCRIPTION
I've deployed this change to the java docker jobs on jenkins-lab if you want to test them.