### PR TITLE
Allow no-arg serverlessPipeline() calls in Jenkinsfiles

### DIFF
--- a/vars/serverlessPipeline.groovy
+++ b/vars/serverlessPipeline.groovy
@@ -21,7 +21,7 @@ import org.cru.jenkins.lib.EnvironmentLoader
  *  testBuildFailureNotifications - if the build should immediately fail with a fake failure,
  *      to test notifications; defaults to false
  */
-def call(Map config) {
+def call(Map config = [:]) {
 
   node('linux') {
     withNotifications(config) {


### PR DESCRIPTION
Should fix the root problem that failed this build:
https://jenkins-lab.cru.org/job/know-god-asset-import/job/master/1/console
