### PR TITLE
Work around Jenkins ruby-runtime plugin problem

### DIFF
--- a/jobs/java-docker-jobs.yml
+++ b/jobs/java-docker-jobs.yml
@@ -62,6 +62,8 @@
       - build-discarder:
           days-to-keep: 64
           artifact-days-to-keep: 64
+      - inject:
+          properties-content: "GEM_PATH= "
 
     node: linux
     scm:


### PR DESCRIPTION
Jenkins and its ruby-runtime plugin set up GEM_PATH that breaks nl.geodienstencentrum.maven:sass-maven-plugin. This commit adds the workaround [prescribed][1] by that plugin's author.

This plugin is used only by thekey, but there's no reason not to set this for all java docker jobs.

[1]: https://github.com/GeoDienstenCentrum/sass-maven-plugin/issues/156#issuecomment-317304000