### PR TITLE
add new configuration for crustore2 magento 2.3

### DIFF
--- a/jobs/app-jobs.yml
+++ b/jobs/app-jobs.yml
@@ -166,8 +166,9 @@
 
 - project:
     name: crustore2
-    description-intro: Builds, tests, & deploys the crustore magento 2.3 docker image.
-    email-recipients: luis.rodriguez@cru.org
+    description-intro: Builds, tests, & deploys the crustore magento 2.3 image.
+    email-recipients: luis.rodriguez@cru.org, steve.blevins@cru.org
+    deploy-production-job: crustore2-deploy
     jobs:
       - 'php-template'
 

--- a/jobs/crustore2-jobs.yml
+++ b/jobs/crustore2-jobs.yml
@@ -1,0 +1,55 @@
+- job:
+    name: crustore2-deploy
+    description: |-
+      Deploys the Magento apps based on role to Production.
+
+      Specifically, this kicks off a deploy-ecs build for each of the four Magento webapps.
+
+    parameters:
+      # Note: these are copy/pasted from the deploy-ecs job list in simple-jobs.yml
+      - string:
+          name: PROJECT_NAME
+          description: The name of the project which should match the name of the docker hub repository
+
+      - string:
+          name: IMAGE_TAG
+          description: The tag of the image to deploy
+
+      - string:
+          name: ENVIRONMENT
+          description: Which environment to deploy to. If not provided, it will be determined from the git branch name.
+
+      - string:
+          name: GIT_BRANCH
+          description: Which git branch is being deployed. This is currently only used to determine ENVIRONMENT
+
+      - string:
+          name: CLUSTER
+          description: Which ECS cluster the app should be deployed to. By default, the stage cluster is used for all non-production environments, and prod is used for all production environments.
+
+      - string:
+          name: IMAGE_NAME
+          description: 'OPTIONAL: Allows for overriding docker image name derived by default from PROJECT_NAME'
+
+    publishers:
+      - trigger-parameterized-builds:
+          - project: deploy-ecs
+            predefined-parameters: |
+              PROJECT_NAME=crustore2
+              IMAGE_NAME=crustore2
+              IMAGE_TAG=$IMAGE_TAG
+              GIT_COMMIT=$GIT_COMMIT
+              GIT_BRANCH=$GIT_BRANCH
+              ENVIRONMENT=$ENVIRONMENT
+              CLUSTER=$CLUSTER
+
+      - trigger-parameterized-builds:
+          - project: deploy-ecs
+            predefined-parameters: |
+              PROJECT_NAME=crustore2-cron
+              IMAGE_NAME=crustore2
+              IMAGE_TAG=$IMAGE_TAG
+              GIT_COMMIT=$GIT_COMMIT
+              GIT_BRANCH=$GIT_BRANCH
+              ENVIRONMENT=$ENVIRONMENT
+              CLUSTER=$CLUSTER

--- a/update_jobs.sh
+++ b/update_jobs.sh
@@ -9,4 +9,5 @@ jenkins-jobs --conf jenkins_jobs.ini update jobs/ep-jobs.yml $@
 jenkins-jobs --conf jenkins_jobs.ini update jobs/ep-promotable-jobs.yml $@
 jenkins-jobs --conf jenkins_jobs.ini update jobs/pipeline-jobs.yml $@
 jenkins-jobs --conf jenkins_jobs.ini update jobs/airflow-jobs.yml $@
+jenkins-jobs --conf jenkins_jobs.ini update jobs/crustore2-jobs.yml $@
 python update_promotable_jobs.py $@


### PR DESCRIPTION
Allow for the deployment of a CRON container.
Magento Requires that when running multiple containers only on run the CRON Task. 
The container will use the same image as the Magento web servers since it needs the Magento binaries to trigger its Cron task. 