### PR TITLE
Add java docker job 'credential-services'

### DIFF
--- a/jobs/java-docker-jobs.yml
+++ b/jobs/java-docker-jobs.yml
@@ -30,6 +30,14 @@
     jobs:
       - '{name}'
 
+- project:
+    name: credential-services
+    description-intro: Builds, tests, & deploys the Credential Services docker image.
+    email-recipients: mike.albert@cru.org
+    base-image: tomcat:8.5.27-jre8
+    jdk: JDK8
+    jobs:
+      - '{name}'
 
 # maven template for java apps on ECS
 - job-template:


### PR DESCRIPTION
This has been created successfully on https://jenkins-lab.cru.org/job/create-jenkins-jobs and then built successfully at https://jenkins-lab.cru.org/job/credential-services/.