### PR TITLE
Always use jenkins-lab branch for jenkins-lab jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,10 @@ How to Add or Update a Job
   * pipeline-jobs.yml --> Multibranch pipeline jobs
 * Test your work
   * Push your feature branch to github
-  * Request Mike Albert to turn on Jenkins Lab, if jenkins-lab.cru.org gives you a 503.
-  * Manually tweak the "Execute Shell" step of create-jenkins-job's [config][1]
-    to use your feature branch.
-    (See the comment there for the syntax.)
-  * Run create-jenkins-job to make your job changes, and run your new or updated job.
+  * Request awsinfrastructure@cru.org to turn on Jenkins Lab, if jenkins-lab.cru.org gives you a 503.
+  * Check in on the [#jenkins-discussions slack channel][3], to coordinate using jenkins-lab
+  * Reset (`--hard`) the jenkins-lab branch to your branch, and force-push it to github (hence the coordination above).
+  * Run [create-jenkins-job][1] to make your job changes, and run your new or updated job.
   * Repeat until bugs are gone
 * Issue a pull request against master and request a code review from Mike Albert or Matt Drees
 * After approval has been given, merge to master and delete the feature branch
@@ -34,5 +33,6 @@ As such it follows the layout requirements:
  * classes (which can hold state or just encapsulate complexity) go in `src`
  * tests go in `test`
 
-[1]: https://jenkins-lab.cru.org/job/create-jenkins-jobs/configure
+[1]: https://jenkins-lab.cru.org/job/create-jenkins-jobs/
 [2]: https://jenkins-prod.cru.org/job/create-jenkins-jobs/
+[3]: https://cru-main.slack.com/messages/CG3S8668P

--- a/jobs/simple-jobs.yml
+++ b/jobs/simple-jobs.yml
@@ -151,9 +151,12 @@
 
     builders:
       - shell: |
-          # if this is jenkins-lab.cru.org, and you want to test your jenkins-jobs changes,
-          # manually add `--extra-vars="jenkins_jobs_version=insert-your-jenkins-job-branch"` below.
-          # Note: when you execute this job, your manual change will be erased.
-          # You'll have to add it again for each time you execute this job.
+          extra_vars_option=""
+          if grep --quiet 'url=https://jenkins-lab.cru.org' /var/lib/jenkins/jenkins-jobs/jenkins_jobs.ini; then
+            echo "This appears to be jenkins-lab; running from jenkins-lab branch"
+            extra_vars_option='--extra-vars="jenkins_jobs_version=jenkins-lab"'
+          else
+            echo "This appears to be jenkins-prod; running from master branch"
+          fi
 
-          ansible-playbook aws_jenkins_add_jobs.yml --tags="jjb_add_jobs"
+          ansible-playbook aws_jenkins_add_jobs.yml --tags="jjb_add_jobs" $extra_vars_option


### PR DESCRIPTION
It will be much nicer to stop editing the job manually.

Note: if jenkins-lab is built from scratch, ansible will use master instead of jenkins-lab
for the jobs. This only applies to rebuilding jobs from within jenkins.
But I think that is ok.

I wish I had done this long ago.