### PR TITLE
add new aem_docker build job, to create and deploy aem dispatcher.

### DIFF
--- a/jobs/aem-dispatcher-jobs.yml
+++ b/jobs/aem-dispatcher-jobs.yml
@@ -1,0 +1,55 @@
+- job:
+    name: aem-dispatcher-deploy
+    description: |-
+      Deploys the AEM dispatcherto Production.
+
+      Specifically, this kicks off a deploy-ecs build for each of the 2 dispatcher webapps.
+
+    parameters:
+      # Note: these are copy/pasted from the deploy-ecs job list in simple-jobs.yml
+      - string:
+          name: PROJECT_NAME
+          description: The name of the project which should match the name of the docker hub repository
+
+      - string:
+          name: IMAGE_TAG
+          description: The tag of the image to deploy
+
+      - string:
+          name: ENVIRONMENT
+          description: Which environment to deploy to. If not provided, it will be determined from the git branch name.
+
+      - string:
+          name: GIT_BRANCH
+          description: Which git branch is being deployed. This is currently only used to determine ENVIRONMENT
+
+      - string:
+          name: CLUSTER
+          description: Which ECS cluster the app should be deployed to. By default, the stage cluster is used for all non-production environments, and prod is used for all production environments.
+
+      - string:
+          name: IMAGE_NAME
+          description: 'OPTIONAL: Allows for overriding docker image name derived by default from PROJECT_NAME'
+
+    publishers:
+      - trigger-parameterized-builds:
+          - project: deploy-ecs
+            predefined-parameters: |
+              PROJECT_NAME=aem-disp-pub1
+              IMAGE_NAME=dispatcher-ps-small
+              IMAGE_TAG=$IMAGE_TAG
+              GIT_COMMIT=$GIT_COMMIT
+              GIT_BRANCH=$GIT_BRANCH
+              ENVIRONMENT=$ENVIRONMENT
+              CLUSTER=$CLUSTER
+
+      - trigger-parameterized-builds:
+          - project: deploy-ecs
+            predefined-parameters: |
+              PROJECT_NAME=aem-disp-pub2
+              IMAGE_NAME=dispatcher-ps-small
+              IMAGE_TAG=$IMAGE_TAG
+              GIT_COMMIT=$GIT_COMMIT
+              GIT_BRANCH=$GIT_BRANCH
+              ENVIRONMENT=$ENVIRONMENT
+              CLUSTER=$CLUSTER

--- a/jobs/app-jobs.yml
+++ b/jobs/app-jobs.yml
@@ -379,6 +379,14 @@
     jobs:
       - 'openresty-template'
 
+- project:
+    name: aem_docker
+    description-intro: Builds, tests, & deploys the AEM apache dispatcher image.
+    email-recipients: luis.rodriguez@cru.org
+    deploy-production-job: aem-dispatcher-deploy
+    jobs:
+      - 'openresty-template'
+
 - job-group:
     name: 'php-template'
     jobs:

--- a/jobs/app-jobs.yml
+++ b/jobs/app-jobs.yml
@@ -383,6 +383,7 @@
     name: aem_docker
     description-intro: Builds, tests, & deploys the AEM apache dispatcher image.
     email-recipients: luis.rodriguez@cru.org
+    deploy-staging-job: aem-dispatcher-deploy
     deploy-production-job: aem-dispatcher-deploy
     jobs:
       - 'openresty-template'

--- a/update_jobs.sh
+++ b/update_jobs.sh
@@ -10,4 +10,5 @@ jenkins-jobs --conf jenkins_jobs.ini update jobs/ep-promotable-jobs.yml $@
 jenkins-jobs --conf jenkins_jobs.ini update jobs/pipeline-jobs.yml $@
 jenkins-jobs --conf jenkins_jobs.ini update jobs/airflow-jobs.yml $@
 jenkins-jobs --conf jenkins_jobs.ini update jobs/crustore2-jobs.yml $@
+jenkins-jobs --conf jenkins_jobs.ini update jobs/aem-dispatcher-jobs.yml $@
 python update_promotable_jobs.py $@


### PR DESCRIPTION
@mattdrees 

Can you take a look at his PR? 

What I'm trying to do is the following. We currently have a single dispatcher per publisher strategy, I would like to implement a container farm strategy where a farm of dispatchers is allocated to each publisher to be able to keep caching load balance between publisher. 

I would like to set up 2 deployment config one for each pub in ecs_config aem-disp-pub1 and aem-disp-pub2, as with the Magento job or Airflow I would like to use the same repo and image, but pass different configuration, in this case, the PUBLISH_IP. 

The repo is aem_docker the build.sh is configured to only build the dispatcher-ps-small image. 

Can you let me know if this would work? what are your thoughts? 

Here is the ecs_config -- https://github.com/CruGlobal/ecs_config/tree/new-app-aem-dispatcher/ecs
Here is the aem_docker  -- https://github.com/CruGlobal/aem_docker

Thanks, 
