### PR TITLE
Remove incorrect quotes

### DIFF
--- a/jobs/simple-jobs.yml
+++ b/jobs/simple-jobs.yml
@@ -154,7 +154,7 @@
           extra_vars_option=""
           if grep --quiet 'url=https://jenkins-lab.cru.org' /var/lib/jenkins/jenkins-jobs/jenkins_jobs.ini; then
             echo "This appears to be jenkins-lab; running from jenkins-lab branch"
-            extra_vars_option='--extra-vars="jenkins_jobs_version=jenkins-lab"'
+            extra_vars_option='--extra-vars=jenkins_jobs_version=jenkins-lab'
           else
             echo "This appears to be jenkins-prod; running from master branch"
           fi


### PR DESCRIPTION
I'm pretty sure that prior to this, the double quotes were being sent to ansible, and ansible doesn't want them.
But it didn't complain, so I didn't notice this in c61097b330d7fe04f2c80bbe065fe581cd1a08d1. Instead, ansible just used the master branch all the time.

It seems likely that, prior to c61097b, the double quotes were unnecessary, but of course bash stripped them away and they didn't cause problems.