### PR TITLE
Remove npx as yarn is installed natively now.

### DIFF
--- a/vars/serverlessPipeline.groovy
+++ b/vars/serverlessPipeline.groovy
@@ -33,8 +33,7 @@ def call(Map config = [:]) {
       stage('Install') {
         switch(config.packageManager) {
           case 'yarn':
-            // Use of npx here will install yarn if not present
-            sh "npx yarn install"
+            sh "yarn install"
             break
           case 'npm':
           default:


### PR DESCRIPTION
This removes the use of `npx` to install yarn if it wasn't present. Yarn is now installed on jenkins by default. https://github.com/CruGlobal/cru-ansible/pull/407