### PR TITLE
WSAPI-53 - Add java docker job for wsapi application

### DIFF
--- a/jobs/app-jobs.yml
+++ b/jobs/app-jobs.yml
@@ -381,6 +381,13 @@
     jobs:
       - 'openresty-template'
 
+- project:
+    name: wsapi
+    description-intro: Builds, tests, & deploys the WSAPI docker image.
+    email-recipients: matt.drees@cru.org, bill.randall@cru.org
+    jobs:
+      - 'generic-template'
+
 - job-group:
     name: 'php-template'
     jobs:
@@ -404,6 +411,12 @@
     jobs:
         - '{name}':
             build-script: react_deploy.sh
+
+- job-group:
+    name: 'generic-template'
+    jobs:
+        - '{name}':
+            build-script: generic_deploy.sh
 
 
 

--- a/jobs/app-jobs.yml
+++ b/jobs/app-jobs.yml
@@ -45,7 +45,7 @@
     description-intro: Builds, tests, & deploys the everystudent.com docker image.
     email-recipients: josh.starcher@cru.org
     jobs:
-      - 'php-template'
+      - 'generic-template'
 
 - project:
     name: global-profile-api
@@ -66,14 +66,14 @@
     description-intro: Builds, tests, & deploys the global-profile-php docker image.
     email-recipients: brian.zoetewey@ccci.org
     jobs:
-      - 'php-template'
+      - 'generic-template'
 
 - project:
     name: wordpress
     description-intro: Builds, tests, & deploys the wordpress docker image.
     email-recipients: brian.zoetewey@ccci.org, josh.starcher@cru.org, david.sudarma@cru.org, john.plastow@cru.org
     jobs:
-      - 'php-template'
+      - 'generic-template'
 
 - project:
     name: global_registry
@@ -86,7 +86,7 @@
     description-intro: Builds, tests, & deploys the gma-app-php docker image.
     email-recipients: brian.zoetewey@ccci.org
     jobs:
-      - 'php-template'
+      - 'generic-template'
 
 - project:
     name: mobile-content-api
@@ -148,14 +148,14 @@
     description-intro: Builds, tests, & deploys the mpd-dashboard-app docker image.
     email-recipients: brian.zoetewey@ccci.org
     jobs:
-      - 'php-template'
+      - 'generic-template'
 
 - project:
     name: crustore
     description-intro: Builds, tests, & deploys the crustore docker image.
     email-recipients: josh.starcher@cru.org
     jobs:
-      - 'php-template'
+      - 'generic-template'
 
 - project:
     name: crustore2
@@ -163,7 +163,7 @@
     email-recipients: luis.rodriguez@cru.org, steve.blevins@cru.org
     deploy-production-job: crustore2-deploy
     jobs:
-      - 'php-template'
+      - 'generic-template'
 
 - project:
     name: mpd_tool
@@ -327,7 +327,7 @@
     description-intro: Builds, tests, & deploys the Model Contracts docker image.
     email-recipients: josh.starcher@cru.org
     jobs:
-      - 'php-template'
+      - 'generic-template'
 
 - project:
     name: snowplow-collector
@@ -387,12 +387,6 @@
     email-recipients: matt.drees@cru.org, bill.randall@cru.org
     jobs:
       - 'generic-template'
-
-- job-group:
-    name: 'php-template'
-    jobs:
-        - '{name}':
-            build-script: php_deploy.sh
 
 - job-group:
     name: 'openresty-template'

--- a/jobs/java-docker-jobs.yml
+++ b/jobs/java-docker-jobs.yml
@@ -13,6 +13,15 @@
       - '{name}'
 
 - project:
+    name: wsapi
+    description-intro: Builds, tests, & deploys the WSAPI docker image.
+    email-recipients: matt.drees@cru.org
+    base-image: jboss/wildfly:17.0.1.Final
+    jdk: JDK11
+    jobs:
+      - '{name}'
+
+- project:
     name: thekey
     description-intro: Builds, tests, & deploys theKey docker image.
     email-recipients: mike.albert@cru.org

--- a/jobs/java-docker-jobs.yml
+++ b/jobs/java-docker-jobs.yml
@@ -13,15 +13,6 @@
       - '{name}'
 
 - project:
-    name: wsapi
-    description-intro: Builds, tests, & deploys the WSAPI docker image.
-    email-recipients: matt.drees@cru.org
-    base-image: jboss/wildfly:17.0.1.Final
-    jdk: JDK11
-    jobs:
-      - '{name}'
-
-- project:
     name: thekey
     description-intro: Builds, tests, & deploys theKey docker image.
     email-recipients: mike.albert@cru.org


### PR DESCRIPTION
A new job for wsapi application was added to java-docker-jobs.yml . Email-recipients is set to matt.drees@cru.org (please let me know if it should be changed after initial testing)