### PR TITLE
Add generic jenkins job for ccp application

### DIFF
--- a/jobs/app-jobs.yml
+++ b/jobs/app-jobs.yml
@@ -388,6 +388,13 @@
     jobs:
       - 'generic-template'
 
+- project:
+    name: ccp
+    description-intro: Builds, tests, & deploys the CCP docker image.
+    email-recipients: matt.drees@cru.org, bill.randall@cru.org
+    jobs:
+      - 'generic-template'
+
 - job-group:
     name: 'openresty-template'
     jobs:


### PR DESCRIPTION
This is a simple job for ccp project using generic-template. The build.sh script was added to the ccp repository but was not merged into dockerization branch yet.