### PR TITLE
Move ERT-API project from docker jobs to ECS template

### DIFF
--- a/jobs/app-jobs.yml
+++ b/jobs/app-jobs.yml
@@ -319,6 +319,13 @@
     jobs:
       - 'ecs-template'
 
+- project:
+    name: ert-api
+    description-intro: Builds & deploys the ERT API docker image.
+    email-recipients: mike.albert@cru.org, lee.braddock@cru.org
+    jobs:
+      - 'ecs-template'
+
 - job-group:
     name: 'ecs-template'
     jobs:

--- a/jobs/java-docker-jobs.yml
+++ b/jobs/java-docker-jobs.yml
@@ -4,15 +4,6 @@
     cluster: ''
 
 - project:
-    name: ert-api
-    description-intro: Builds, tests, & deploys the ERT API docker image.
-    email-recipients: mike.albert@cru.org
-    base-image: 056154071827.dkr.ecr.us-east-1.amazonaws.com/base-image-wildfly:syslog-tcp-socket-fix
-    jdk: JDK8
-    jobs:
-      - '{name}'
-
-- project:
     name: thekey
     description-intro: Builds, tests, & deploys theKey docker image.
     email-recipients: mike.albert@cru.org


### PR DESCRIPTION
Please review changes in jenkins job for ERT-API project. 

I did not update ECS configuration for the project (https://github.com/CruGlobal/ecs_config/blob/master/ecs/ert-api/aws.json) since it was set for the previous docker image but environment variables file should be regenerated there because of migration "database connection url" -> "database host, database port, db name".

I also was not able to reach 'health-check-path' (/eventhub-api/index.html) mentioned in the configuration (https://screencast.com/t/bNHhv2nw). If it is not something linked to the deploy process we can specify '/docs/' (quick but not really good solution) or I can add 'green.html' file to the project.