### PR TITLE
Add generic jenkins job for etimesheet application

### DIFF
--- a/jobs/app-jobs.yml
+++ b/jobs/app-jobs.yml
@@ -255,6 +255,13 @@
       - 'generic-template'
 
 - project:
+    name: etimesheet
+    description-intro: Builds, tests, & deploys the eTimesheet docker image.
+    email-recipients: matt.drees@cru.org, bill.randall@cru.org
+    jobs:
+      - 'generic-template'
+
+- project:
     name: atlantis
     description-intro: Builds and deploys the Atlantis docker image.
     email-recipients: luis.rodriguez@cru.org, brian.zoetewey@cru.org


### PR DESCRIPTION
This is a simple job for etimesheet project using generic-template. The build.sh script was added to the etimesheet repository but was not merged into dockerization branch yet.