### PR TITLE
Add generic jenkins job for pshr-listener application

### DIFF
--- a/jobs/app-jobs.yml
+++ b/jobs/app-jobs.yml
@@ -69,6 +69,13 @@
       - 'generic-template'
 
 - project:
+    name: pshr-listener
+    description-intro: Builds, tests, & deploys the pshr-listener docker image.
+    email-recipients: matt.drees@cru.org
+    jobs:
+      - 'generic-template'
+
+- project:
     name: wordpress
     description-intro: Builds, tests, & deploys the wordpress docker image.
     email-recipients: brian.zoetewey@ccci.org, josh.starcher@cru.org, david.sudarma@cru.org, john.plastow@cru.org


### PR DESCRIPTION
Hi Matt,
This is a new jenkins job for pshr-listener. Build.sh was added there but was not merged into dockerization branch yet.