### PR TITLE
Add generic jenkins job for ssw application

### DIFF
--- a/jobs/app-jobs.yml
+++ b/jobs/app-jobs.yml
@@ -227,6 +227,13 @@
       - 'rails-template'
 
 - project:
+    name: ssw
+    description-intro: Builds, tests, & deploys the ssw docker image.
+    email-recipients: matt.drees@cru.org, bill.randall@cru.org
+    jobs:
+      - 'generic-template'
+
+- project:
     name: staff-conf-onsite
     description-intro: Builds, tests, & deploys the staff conference onsite docker image.
     email-recipients: josh.starcher@cru.org


### PR DESCRIPTION
Hi Matt,
This is a new jenkins job for SSW. Build.sh was added there but was not merged into dockerization branch yet.

