### PR TITLE
scale-of-belief-lambda is production only now that collection is managed

### DIFF
--- a/jobs/pipeline-jobs.yml
+++ b/jobs/pipeline-jobs.yml
@@ -25,6 +25,7 @@
       Scale-of-belief lambda (serverless) project.
     jobs:
       - 'pipeline-template':
+          branches: master
 
 - project:
     name: scale-of-belief-import


### PR DESCRIPTION
scale-of-belief-lambda only has production resources now that pipeline is managed by Snowplow contractors.