### PR TITLE
Update rbenv default ruby version to 2.3.8

### DIFF
--- a/jobs/app-jobs.yml
+++ b/jobs/app-jobs.yml
@@ -539,4 +539,4 @@
       - build-name:
           name: '$GIT_BRANCH #$BUILD_NUMBER'
       - rbenv:
-          ruby-version: 2.3.1
+          ruby-version: 2.3.8


### PR DESCRIPTION
The bundler (that rbenv installs) complains that rubygems is too old,
otherwise.

This version (2.3.8) is the 2.3 version supported by base-image-ruby-arg,
and I doubt any rails apps are relying on this default anyway,
so I think this is pretty safe.