### PR TITLE
Add deployment of cron contianer for staging environment.

### DIFF
--- a/jobs/app-jobs.yml
+++ b/jobs/app-jobs.yml
@@ -161,6 +161,7 @@
     name: crustore2
     description-intro: Builds, tests, & deploys the crustore magento 2.3 image.
     email-recipients: luis.rodriguez@cru.org, steve.blevins@cru.org
+    deploy-staging-job: crustore2-deploy
     deploy-production-job: crustore2-deploy
     jobs:
       - 'generic-template'


### PR DESCRIPTION
While deploying to production I discover that when running multiple instances of Magento there are certain tasks that need to run just once during the container startup script. Adding the CRON container to Stage will facilitate testing. 

List of tasks that are required to run once will be executed in the CRON container.
Flush Redis cache
setup:upgrade
setup:static-content:deploy
cache:clean
indexer:reindex

The following task will run on all container:
setup:di:compile

Related to: 
CruGlobal/crustore2/pull/91

Dependent on:
CruGlobal/ecs_config/pull/539
CruGlobal/cru-terraform#231

