### PR TITLE
Remove retired apps

### DIFF
--- a/jobs/app-jobs.yml
+++ b/jobs/app-jobs.yml
@@ -254,34 +254,6 @@
       - 'generic-template'
 
 - project:
-    name: snowplow-collector
-    description-intro: Builds, tests, & deploys the snowplow collector docker image.
-    email-recipients: josh.starcher@cru.org
-    jobs:
-      - 'openresty-template'
-
-- project:
-    name: snowplow-s3loader
-    description-intro: Builds, tests, & deploys the snowplow s3 Loader docker image.
-    email-recipients: josh.starcher@cru.org, luis.rodriguez@cru.org
-    jobs:
-      - 'openresty-template'
-
-- project:
-    name: snowplow-dataflow
-    description-intro: Builds, tests, & deploys the snowplow dataflow docker image.
-    email-recipients: josh.starcher@cru.org, luis.rodriguez@cru.org
-    jobs:
-      - 'openresty-template'
-
-- project:
-    name: snowplow-enrich
-    description-intro: Builds, tests, & deploys the snowplow enrich docker image.
-    email-recipients: josh.starcher@cru.org, luis.rodriguez@cru.org
-    jobs:
-      - 'openresty-template'
-
-- project:
     name: syslog-fluentd
     description-intro: Builds, tests, & deploys the syslog-fluentd docker image.
     email-recipients: josh.starcher@cru.org, bill.baker@cru.org

--- a/jobs/app-jobs.yml
+++ b/jobs/app-jobs.yml
@@ -27,20 +27,6 @@
       - 'rails-template'
 
 - project:
-    name: college-bound
-    description-intro: Builds and deploys the college-bound image.
-    email-recipients: spencer.oberstadt@cru.org
-    jobs:
-      - 'rails-template'
-
-- project:
-    name: cruprojects
-    description-intro: Builds, tests, & deploys the cruprojects.com docker image.
-    email-recipients: spencer.oberstadt@cru.org
-    jobs:
-      - 'rails-template'
-
-- project:
     name: everystudent-web
     description-intro: Builds, tests, & deploys the everystudent.com docker image.
     email-recipients: josh.starcher@cru.org
@@ -110,13 +96,6 @@
       - 'rails-template'
 
 - project:
-    name: ministry_view_api
-    description-intro: Builds, tests, & deploys the MinistryView API docker image.
-    email-recipients: brian.zoetewey@ccci.org
-    jobs:
-      - 'rails-template'
-
-- project:
     name: missionhub-api
     description-intro: Builds, tests, & deploys the MissionHub API docker image.
     jobs:
@@ -127,20 +106,6 @@
     description-intro: Builds, tests, & deploys the CampusCRM API docker image.
     jobs:
       - 'rails-template'
-
-- project:
-    name: mpd-dashboard-api
-    description-intro: Builds, tests, & deploys the mpd-dashboard-api docker image.
-    email-recipients: josh.starcher@cru.org, brian.zoetewey@ccci.org, adam.meyer@cru.org
-    jobs:
-      - 'rails-template'
-
-- project:
-    name: mpd-dashboard-app
-    description-intro: Builds, tests, & deploys the mpd-dashboard-app docker image.
-    email-recipients: brian.zoetewey@ccci.org
-    jobs:
-      - 'generic-template'
 
 - project:
     name: crustore
@@ -173,26 +138,6 @@
       - 'rails-template'
 
 - project:
-    name: ministry_locator
-    description-intro: Builds, tests, & deploys the ministry locator docker image.
-    jobs:
-      - 'rails-template'
-
-- project:
-    name: ministry_mapper
-    description-intro: Builds, tests, & deploys the ministry mapper docker image.
-    email-recipients: josh.starcher@cru.org
-    jobs:
-      - 'rails-template'
-
-- project:
-    name: oauth_server
-    description-intro: Builds, tests, & deploys the oauth_server docker image.
-    email-recipients: josh.starcher@cru.org
-    jobs:
-      - 'rails-template'
-
-- project:
     name: pr
     description-intro: Builds, tests, & deploys the Panorama docker image.
     email-recipients: josh.starcher@cru.org, justin.sabelko@cru.org
@@ -210,12 +155,6 @@
     name: rails-infrastructure-canary
     description-intro: Builds a simplistic rails app, which only serves to prove out the ci & deployment infrastructure.
     cluster: lab
-    jobs:
-      - 'rails-template'
-
-- project:
-    name: rideshare
-    description-intro: Builds, tests, & deploys the rideshare docker image.
     jobs:
       - 'rails-template'
 
@@ -270,13 +209,6 @@
 - project:
     name: watchthinkchat
     description-intro: Builds, tests, & deploys the WatchThinkChat docker image.
-    jobs:
-      - 'rails-template'
-
-- project:
-    name: escomm
-    description-intro: Builds, tests, & deploys the Personalized EveryStudent Series docker image
-    email-recipients: asaph.yuan@cru.org, david.raffensperger@cru.org
     jobs:
       - 'rails-template'
 

--- a/jobs/app-jobs.yml
+++ b/jobs/app-jobs.yml
@@ -48,25 +48,11 @@
       - 'generic-template'
 
 - project:
-    name: global-profile-api
-    description-intro: Builds, tests, & deploys the global-profile-api docker image.
-    email-recipients: brian.zoetewey@ccci.org
-    jobs:
-      - 'rails-template'
-
-- project:
     name: global360
     description-intro: Builds, tests, & deploys the global360 docker image.
     email-recipients: josh.starcher@cru.org
     jobs:
       - 'rails-template'
-
-- project:
-    name: global-profile-php
-    description-intro: Builds, tests, & deploys the global-profile-php docker image.
-    email-recipients: brian.zoetewey@ccci.org
-    jobs:
-      - 'generic-template'
 
 - project:
     name: pshr-listener


### PR DESCRIPTION
This removes `global-profile-(app|api)` for https://secure.helpscout.net/conversation/1135843528/437156.

Also removes any retired apps that still existed.
https://docs.google.com/spreadsheets/d/1LCQILnneFU-jKVe5wtU39hGRjnPKE-r0j9feOIYbd9M/edit#gid=0