### PR TITLE
Update serverless pipeline google and parameter store.

### DIFF
--- a/src/org/cru/jenkins/lib/EnvironmentLoader.groovy
+++ b/src/org/cru/jenkins/lib/EnvironmentLoader.groovy
@@ -35,7 +35,7 @@ class EnvironmentLoader implements Serializable {
         eval "\$(~/.rbenv/bin/rbenv init -)"
 
         # Execute script in an assumed environment
-        \${ECS_CONFIG}/bin/jenkins-pipeline -v -e \${ENVIRONMENT} -n \${PROJECT_NAME} -- "${script}"
+        \${ECS_CONFIG}/bin/jenkins-pipeline --verbose --env \${ENVIRONMENT} --name \${PROJECT_NAME} -- "${script}"
       """.stripIndent()
     }
   }

--- a/src/org/cru/jenkins/lib/EnvironmentLoader.groovy
+++ b/src/org/cru/jenkins/lib/EnvironmentLoader.groovy
@@ -31,12 +31,13 @@ class EnvironmentLoader implements Serializable {
       checkoutIfNecessary(ecsConfigDir)
 
       steps.bash """\
-        source \${ECS_CONFIG}/bin/load_environment.sh;
-        load_environment;
-        ${script}
-        """.stripIndent()
-    }
+        # Source rbenv to setup ruby in the path
+        eval "\$(~/.rbenv/bin/rbenv init -)"
 
+        # Execute script in an assumed environment
+        \${ECS_CONFIG}/bin/jenkins-pipeline -v -e \${ENVIRONMENT} -n \${PROJECT_NAME} -- "${script}"
+      """.stripIndent()
+    }
   }
 
   private void checkoutIfNecessary(ecsConfigDir) {

--- a/vars/serverlessPipeline.groovy
+++ b/vars/serverlessPipeline.groovy
@@ -6,8 +6,6 @@ import org.cru.jenkins.lib.EnvironmentLoader
  * Defines a jenkins pipeline for serverless projects.
  *
  * Config options:
- *  assumeRole - ARN of the role to assume during deployment. Leave empty to default to the
- *      jenkins EC2 role.
  *  confirmAllBranches - if all branches should be subject to deployment confirmation prompts,
  *      and not just production; defaults to false
  *  defaultEnvironment - the environment to use if the branch is neither 'master' nor 'staging';
@@ -60,35 +58,8 @@ private void performDeploy(config) {
     deploymentWork: '.deployment',
     this
   )
-  def script = ''
 
-  if(config.assumeRole) {
-    // Custom aws cli to assume role because aws-js-sdk doesn't support credential_source config directive
-    // See https://github.com/serverless/serverless/issues/3833#issuecomment-471318601
-    script = """\
-      # Use custom credentials file
-      export AWS_SHARED_CREDENTIALS_FILE=\"\$(pwd)/.credentials\";
-
-      # Assume deployment role manually
-      assumed_role_creds=\$(aws sts assume-role --role-arn $config.assumeRole \\
-        --role-session-name serverless --output json | \\
-        jq -r '.Credentials.AccessKeyId, .Credentials.SecretAccessKey, .Credentials.SessionToken');
-      IFS=\" \" readarray -t parts <<< \"\$assumed_role_creds\";
-
-      # Populate credentials file with access keys and session token
-      aws configure set aws_access_key_id \"\${parts[0]}\" --profile serverless;
-      aws configure set aws_secret_access_key \"\${parts[1]}\" --profile serverless;
-      aws configure set aws_session_token \"\${parts[2]}\" --profile serverless;
-
-      # Define profile (by setting at least region) in ~/.aws/config otherwise serverless won't find it
-      export AWS_SDK_LOAD_CONFIG=1;
-      aws configure set region us-east-1 --profile serverless;
-      SLS_DEBUG=* npx serverless deploy --stage ${environment} --verbose --aws-profile serverless;
-    """.stripIndent()
-  } else {
-    script = "SLS_DEBUG=* npx serverless deploy --stage ${environment} --verbose;"
-  }
-  loader.bash script
+  loader.bash "printenv GOOGLE_KEYFILE > keyfile.json; SLS_DEBUG=* npx serverless deploy --stage ${environment} --verbose;"
 
   notifyRollbarOfDeployment(loader)
 }


### PR DESCRIPTION
Update serverless pipeline to assume the task role and export ENV from parameter store before deploying the app.
Add support for Google cloud functions.

This update will break existing serverless-pipeline deployments, which I felt was OK, as we rarely deploy them, and I'll be updating all of them in the next few days.