### PR TITLE
Double escape env vars

### DIFF
--- a/vars/notifyRollbarOfDeployment.groovy
+++ b/vars/notifyRollbarOfDeployment.groovy
@@ -12,15 +12,14 @@ def call(EnvironmentLoader loader) {
   def gitCommit = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
 
   script = """
-    if [ -z "\${ROLLBAR_ACCESS_TOKEN}"];
-    then
-      echo "No ROLLBAR_ACCESS_TOKEN; skipping rollbar deployment notification"
+    if [ -z "\\\${ROLLBAR_ACCESS_TOKEN}" ]; then
+      echo "No ROLLBAR_ACCESS_TOKEN, skipping rollbar deployment notification";
       exit 0;
     fi
 
     curl https://api.rollbar.com/api/1/deploy/ \\
-      --form access_token="\${ROLLBAR_ACCESS_TOKEN}" \\
-      --form environment="\${ENVIRONMENT}" \\
+      --form access_token="\\\${ROLLBAR_ACCESS_TOKEN}" \\
+      --form environment="\\\${ENVIRONMENT}" \\
       --form revision="${gitCommit}" \\
       --form local_username="${localUsername}" \\
       --form comment="${env.BUILD_URL}"


### PR DESCRIPTION
Because we are passing this into another program now (`jenkins-pipeline` ruby script), it was evaluating the environment variables before ruby saw them. This escapes them so they get evaluated in the assumed env.