### PR TITLE
Add familylife-cvent-api pipeline job

### DIFF
--- a/jobs/pipeline-jobs.yml
+++ b/jobs/pipeline-jobs.yml
@@ -114,6 +114,14 @@
       - 'pipeline-template':
           branches: master
 
+- project:
+    name: FamilyLife-CventAPI
+    description: |
+      FamilyLife Cvent application (λ functions).
+    jobs:
+      - 'pipeline-template':
+          branches: staging master
+
 - job-template:
     id: pipeline-template
 


### PR DESCRIPTION
I'm not exactly sure how jenkins-jobs templates the yaml, but my hope is that this is the correct config to override the repository name as cvent-api uses a non-standard github repo name.