### PR TITLE
Rename scale-of-belief-lambda to scale-of-belief

### DIFF
--- a/jobs/pipeline-jobs.yml
+++ b/jobs/pipeline-jobs.yml
@@ -20,7 +20,7 @@
 
 
 - project:
-    name: scale-of-belief-lambda
+    name: scale-of-belief
     description: |
       Scale-of-belief lambda (serverless) project.
     jobs:


### PR DESCRIPTION
There was a name mismatch between the serverless project and the terraform project which was causing the project to no longer be able to be deployed. This renames the terraform/jenkins to match serverless which should fix it.